### PR TITLE
build(release): add GitHub release publishing and refactor semantic-release prepare step

### DIFF
--- a/.github/workflows/cicd-2-publish.yaml
+++ b/.github/workflows/cicd-2-publish.yaml
@@ -70,6 +70,7 @@ jobs:
             @semantic-release/changelog@6.0.3 \
             @semantic-release/git@10.0.1 \
             @semantic-release/exec@7.1.0 \
+            @semantic-release/github@12.0.8 \
             conventional-changelog-conventionalcommits@9.1.0
       - name: "Semantic Release"
         id: semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -26,7 +26,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "find infrastructure/modules -name context.tf -exec sed -i.bak -e 's#//infrastructure/modules/tags?ref=${lastRelease.version}#//infrastructure/modules/tags?ref=${nextRelease.version}#g' {} + && find infrastructure/modules -iname readme.md -exec sed -i.bak -e 's#//infrastructure/modules/tags | ${lastRelease.version} |#//infrastructure/modules/tags | ${nextRelease.version} |#g' {} + && find infrastructure/modules -name '*.bak' -delete"
+        "prepareCmd": "node scripts/release/update-tags-module-version.cjs ${lastRelease.version} ${nextRelease.version}"
       }
     ],
     [

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -26,10 +26,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": [
-          "find infrastructure/modules -name context.tf -exec sed -i '' -e 's#//infrastructure/modules/tags?ref=${lastRelease.version}#//infrastructure/modules/tags?ref=${nextRelease.version}#g' {} +",
-          "find infrastructure/modules -iname readme.md -exec sed -i '' -e 's#//infrastructure/modules/tags | ${lastRelease.version} |#//infrastructure/modules/tags | ${nextRelease.version} |#g' {} +"
-        ]
+        "prepareCmd": "find infrastructure/modules -name context.tf -exec sed -i.bak -e 's#//infrastructure/modules/tags?ref=${lastRelease.version}#//infrastructure/modules/tags?ref=${nextRelease.version}#g' {} + && find infrastructure/modules -iname readme.md -exec sed -i.bak -e 's#//infrastructure/modules/tags | ${lastRelease.version} |#//infrastructure/modules/tags | ${nextRelease.version} |#g' {} + && find infrastructure/modules -name '*.bak' -delete"
       }
     ],
     [

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -39,6 +39,14 @@
         ],
         "message": "chore(release): version ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "addReleases": "bottom",
+        "successComment": false,
+        "releaseBodyTemplate": "## What's Changed\n\n<%= nextRelease.notes %>\n\n**Full Changelog**:\n[CHANGELOG.md](https://github.com/NHSDigital/screening-terraform-modules-aws/blob/main/CHANGELOG.md)\n**Comparison**:\nhttps://github.com/NHSDigital/screening-terraform-modules-aws/compare/<%= lastRelease.gitTag %>...<%= nextRelease.gitTag %>"
+      }
     ]
   ]
 }

--- a/scripts/release/update-tags-module-version.cjs
+++ b/scripts/release/update-tags-module-version.cjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+/**
+ * Update references to the local tags module between semantic-release versions.
+ *
+ * Why this exists:
+ * - Keeping release-time string replacements in a standalone script is easier
+ *   to read, test, and maintain than an inline shell one-liner in .releaserc.
+ * - It avoids platform-specific sed/find behavior differences.
+ *
+ * Expected arguments:
+ *   1) last release version (for example: 1.2.3)
+ *   2) next release version (for example: 1.2.4)
+ *
+ * Called by semantic-release exec plugin as:
+ *   node scripts/release/update-tags-module-version.cjs "${lastRelease.version}" "${nextRelease.version}"
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const MODULES_ROOT = path.join("infrastructure", "modules");
+const TARGET_FILE_NAMES = new Set(["context.tf", "readme.md"]);
+
+const [lastVersion, nextVersion] = process.argv.slice(2);
+
+if (!lastVersion || !nextVersion) {
+  console.error(
+    "Usage: node scripts/release/update-tags-module-version.cjs <lastVersion> <nextVersion>"
+  );
+  process.exit(1);
+}
+
+/**
+ * Recursively list all files under a root directory.
+ */
+function listFilesRecursively(dirPath) {
+  const entries = fs.readdirSync(dirPath, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...listFilesRecursively(fullPath));
+      continue;
+    }
+
+    files.push(fullPath);
+  }
+
+  return files;
+}
+
+/**
+ * Replace all occurrences of release-pinned tags module references.
+ */
+function updateContent(content, fromVersion, toVersion) {
+  return content
+    .replaceAll(
+      `//infrastructure/modules/tags?ref=${fromVersion}`,
+      `//infrastructure/modules/tags?ref=${toVersion}`
+    )
+    .replaceAll(
+      `//infrastructure/modules/tags | ${fromVersion} |`,
+      `//infrastructure/modules/tags | ${toVersion} |`
+    );
+}
+
+if (!fs.existsSync(MODULES_ROOT)) {
+  console.error(`Directory not found: ${MODULES_ROOT}`);
+  process.exit(1);
+}
+
+const allFiles = listFilesRecursively(MODULES_ROOT);
+let updatedFilesCount = 0;
+
+for (const filePath of allFiles) {
+  const fileName = path.basename(filePath).toLowerCase();
+
+  // Only process files where these references are expected.
+  if (!TARGET_FILE_NAMES.has(fileName)) continue;
+
+  const original = fs.readFileSync(filePath, "utf8");
+  const updated = updateContent(original, lastVersion, nextVersion);
+
+  // Avoid touching unchanged files to keep release commits clean.
+  if (updated === original) continue;
+
+  fs.writeFileSync(filePath, updated, "utf8");
+  updatedFilesCount += 1;
+}
+
+console.log(
+  `Updated tags module references from ${lastVersion} to ${nextVersion} in ${updatedFilesCount} file(s).`
+);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Add GitHub release publishing to the semantic-release pipeline.
- Improve release note and changelog integration for automated releases.
- Replace the inline prepare command with a standalone script to improve readability and maintainability.
- Optimize prepare step updates for context.tf and README.md references.

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
