### PR TITLE
build: update terraform_validate pre-commit hook execution behaviour

### DIFF
--- a/.github/skills/pre-commit-hooks.skill.md
+++ b/.github/skills/pre-commit-hooks.skill.md
@@ -86,7 +86,9 @@ pre-commit run terraform_fmt --files infrastructure/modules/vpc/main.tf
 
 #### 1.2 `terraform_validate` — Validate Terraform Configuration
 
-**What it does:** Ensures Terraform syntax is valid and modules are properly configured. Uses `terraform init -lockfile=readonly` internally.
+**What it does:** Ensures Terraform syntax is valid and modules are properly configured.
+
+Local pre-commit runs allow Terraform to refresh `.terraform.lock.hcl` when provider constraints change. In CI, `terraform_validate` is run with `terraform init -lockfile=readonly` so checks remain deterministic and do not mutate lockfiles.
 
 **When it fails:**
 

--- a/.github/workflows/stage-1-pre-commit.yml
+++ b/.github/workflows/stage-1-pre-commit.yml
@@ -91,6 +91,11 @@ jobs:
           export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
           hooks='${{ matrix.shard.hooks }}'
           for hook in ${hooks}; do
+            if [[ "${hook}" == "terraform_validate" ]]; then
+              export TF_CLI_ARGS_init="-lockfile=readonly"
+            else
+              unset TF_CLI_ARGS_init
+            fi
             echo "Running hook: ${hook}"
             mise x -- pre-commit run --all-files --show-diff-on-failure "$hook"
           done

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,6 @@ repos:
           - --args=-json
           - --args=-no-color
           - --env-vars=AWS_DEFAULT_REGION=eu-west-2
-          - --tf-init-args=-lockfile=readonly
           - --hook-config=--retry-once-with-cleanup=true
       - id: terraform_tflint
         # exclude: ^infrastructure/modules/(aws-backup-destination|aws-backup-source)/

--- a/docs/user-guides/Pre_commit_hooks_reference.md
+++ b/docs/user-guides/Pre_commit_hooks_reference.md
@@ -92,7 +92,9 @@ pre-commit run terraform_fmt --files infrastructure/modules/vpc/main.tf
 
 #### `terraform_validate` — Validate Configuration
 
-**What it does:** Checks that Terraform syntax is valid and modules are properly configured. Uses `terraform init -lockfile=readonly` internally.
+**What it does:** Checks that Terraform syntax is valid and modules are properly configured.
+
+Local pre-commit runs allow Terraform to refresh `.terraform.lock.hcl` when provider constraints change. In CI, `terraform_validate` runs with `terraform init -lockfile=readonly` so checks stay deterministic and do not mutate lockfiles.
 
 **When it fails:**
 


### PR DESCRIPTION
Documentation clarifies the behavior of the `terraform_validate` hook, explaining how it operates differently in local and CI environments. This change enhances understanding of the hook's functionality and ensures users are aware of its impact on lockfiles.

