### PR TITLE
feat: update pre-commit hooks for improved Terraform lockfile handling

### DIFF
--- a/.github/skills/pre-commit-hooks.skill.md
+++ b/.github/skills/pre-commit-hooks.skill.md
@@ -88,7 +88,9 @@ pre-commit run terraform_fmt --files infrastructure/modules/vpc/main.tf
 
 **What it does:** Ensures Terraform syntax is valid and modules are properly configured.
 
-Local pre-commit runs allow Terraform to refresh `.terraform.lock.hcl` when provider constraints change. In CI, `terraform_validate` is run with `terraform init -lockfile=readonly` so checks remain deterministic and do not mutate lockfiles.
+In this repository's pre-commit configuration, `terraform_providers_lock` runs before `terraform_validate` so  lock file platform coverage is reconciled first.
+
+Local pre-commit runs allow Terraform to refresh `.terraform.lock.hcl` when provider constraints change. In CI, `terraform_validate` is run with `terraform init -lockfile=readonly` so checks remain deterministic and do not mutate lock files.
 
 **When it fails:**
 

--- a/.github/workflows/stage-1-pre-commit.yml
+++ b/.github/workflows/stage-1-pre-commit.yml
@@ -40,8 +40,8 @@ jobs:
               check-terraform-format
           - name: "terraform-validate-docs-lock"
             hooks: >-
-              generate-terraform-providers terraform_validate terraform_docs
-              terraform_providers_lock
+              generate-terraform-providers terraform_providers_lock
+              terraform_validate terraform_docs
     steps:
       - name: "Checkout code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,14 @@ repos:
         - --args=-no-color
         - --args=-diff
         - --args=-recursive
+      - id: terraform_providers_lock
+        args:
+          - --args=-platform=linux_arm64
+          - --args=-platform=linux_amd64
+          - --args=-platform=darwin_arm64
+          - --args=-platform=darwin_amd64
+          - --args=-platform=windows_amd64
+          - --hook-config=--mode=regenerate-lockfile-if-some-platform-missed
       - id: terraform_validate
         args:
           - --args=-json
@@ -65,11 +73,6 @@ repos:
           - --hook-config=--create-file-if-not-exist=false
           - '--hook-config=--custom-marker-begin=<!-- vale off -->\n<!-- markdownlint-disable -->\n<!-- BEGIN_TF_DOCS -->'
           - '--hook-config=--custom-marker-end=<!-- END_TF_DOCS -->\n<!-- markdownlint-restore -->\n<!-- vale on -->'
-      - id: terraform_providers_lock
-        args:
-          - --hook-config=--mode=check-lockfile-is-cross-platform
-          # - --hook-config=--mode=always-regenerate-lockfile
-          - --hook-config=--mode=regenerate-lockfile-if-some-platform-missed
 
   # --------------------------------------------------------------------------
   # General file hygiene

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ This repository enforces **26 hooks** across six categories:
 
 | Category | Hooks | Purpose |
 | --- | --- | --- |
-| **Terraform** (5) | `terraform_fmt`, `terraform_validate`, `terraform_tflint`, `terraform_docs`, `terraform_providers_lock` | Format, validate, lint, document, and lock Terraform modules |
+| **Terraform** (5) | `terraform_fmt`, `terraform_providers_lock`, `terraform_validate`, `terraform_tflint`, `terraform_docs` | Format, lock, validate, lint, and document Terraform modules |
 | **File Hygiene** (8) | `check-added-large-files`, `check-merge-conflict`, `no-commit-to-branch`, `end-of-file-fixer`, `trailing-whitespace`, `check-yaml`, `check-case-conflict`, `mixed-line-ending` | Prevent commits of large files, merge conflicts, direct commits to main, and enforce line ending consistency |
 | **Shell Scripts** (1) | `shellcheck` | Lint Bash/shell scripts for errors and bad practices |
 | **File Formatting** (4) | `check-file-format`, `check-markdown-format`, `check-english-usage`, `check-terraform-format` | Enforce consistent formatting and British English in documentation |

--- a/docs/user-guides/Pre_commit_hooks_reference.md
+++ b/docs/user-guides/Pre_commit_hooks_reference.md
@@ -94,7 +94,9 @@ pre-commit run terraform_fmt --files infrastructure/modules/vpc/main.tf
 
 **What it does:** Checks that Terraform syntax is valid and modules are properly configured.
 
-Local pre-commit runs allow Terraform to refresh `.terraform.lock.hcl` when provider constraints change. In CI, `terraform_validate` runs with `terraform init -lockfile=readonly` so checks stay deterministic and do not mutate lockfiles.
+In this repository's pre-commit configuration, `terraform_providers_lock` runs before `terraform_validate` so lock file platform coverage is reconciled first.
+
+Local pre-commit runs allow Terraform to refresh `.terraform.lock.hcl` when provider constraints change. In CI, `terraform_validate` runs with `terraform init -lockfile=readonly` so checks stay deterministic and do not mutate lock files.
 
 **When it fails:**
 
@@ -212,7 +214,7 @@ terraform-docs markdown . > README.md
 
 ```text
 ✗ Failed
-Lockfile is not cross-platform
+Lock file is not cross-platform
 Missing platform: darwin_amd64
 ```
 

--- a/scripts/terraform/upgrade-module.sh
+++ b/scripts/terraform/upgrade-module.sh
@@ -6,6 +6,7 @@ repo_root="$(git rev-parse --show-toplevel)"
 lock_platforms=(
   linux_arm64
   linux_amd64
+  darwin_arm64
   darwin_amd64
   windows_amd64
 )


### PR DESCRIPTION
Improve the pre-commit configuration to ensure proper handling of Terraform lockfiles across different platforms. This change enhances the order of operations for the hooks, ensuring that platform coverage is reconciled before validation. Additionally, update documentation to reflect these changes.

