### PR TITLE
fix: improve error handling in pre-commit hooks for Terraform documentation generation

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -90,7 +90,7 @@ jobs:
           mapfile -t modules_to_upgrade < <(
             git diff --name-only "$base_sha...HEAD" \
               | grep '^infrastructure/modules/.*/versions\.tf$' \
-              | xargs -n1 dirname \
+              | xargs -r -n1 dirname \
               | sort -u
           )
 
@@ -111,7 +111,7 @@ jobs:
 
           mise x -- pre-commit run --all-files generate-terraform-providers
           mise x -- pre-commit run --all-files terraform_providers_lock
-          mise x -- pre-commit run --all-files terraform_docs
+          mise x -- pre-commit run --all-files terraform_docs || true
           mise x -- pre-commit run --all-files regenerate-dependabot-config
 
       - name: "Detect changes"


### PR DESCRIPTION
Enhance error handling in pre-commit hooks to ensure that failures in generating Terraform documentation do not halt the process. This change improves the robustness of the workflow by allowing subsequent tasks to continue even if documentation generation fails.

## Description

Enhance error handling in pre-commit hooks to ensure that failures in generating Terraform documentation do not halt the process. This change improves the robustness of the workflow by allowing subsequent tasks to continue even if documentation generation fails.

## Context

This change is required to improve the reliability of the pre-commit hooks, specifically for Terraform documentation generation. It addresses potential issues where errors in documentation generation could disrupt the overall workflow.

## Type of changes

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.

