### PR TITLE
ci: enhance secret scanning with staged changes and complete history

### DIFF
--- a/.github/instructions/pre-commit-hooks.instructions.md
+++ b/.github/instructions/pre-commit-hooks.instructions.md
@@ -42,7 +42,8 @@ git commit -m "type(scope): description"
 
 - `detect-aws-credentials` — detects embedded secrets
 - `detect-private-key` — detects leaked private keys
-- `scan-secrets` — scans git history for secrets
+- `scan-secrets-staged-changes` — scans staged changes for secrets (runs on `git commit`)
+- `scan-secrets-whole-history` — scans entire git history for secrets (runs on `pre-commit run --all-files`)
 - `terraform_validate` — ensures modules are syntactically valid
 - `regenerate-dependabot-config` — ensures Dependabot watches all modules
 - `no-commit-to-branch` — enforces PR workflow

--- a/.github/skills/pre-commit-hooks.skill.md
+++ b/.github/skills/pre-commit-hooks.skill.md
@@ -509,16 +509,62 @@ vale README.md infrastructure/AGENTS.md
 
 ### Category 5: Security & Secrets
 
-#### 5.1 `scan-secrets` — Secret Scanning via Gitleaks
+#### 5.1 `scan-secrets-staged-changes` — Secret Scanning (Staged Files)
 
-**What it does:** Scans entire git history for embedded secrets (API keys, credentials, etc.) using Gitleaks.
+**What it does:** Scans staged changes for embedded secrets (API keys, credentials, etc.) using Gitleaks. Runs automatically on `git commit`.
 
 **When it fails:**
 
 ```text
 Leaks found: 1
-File: .env.example
+File: .env
 Secret: aws_secret_access_key = "AKIA2EXAMPLE..."
+```
+
+**Common false positives:**
+
+- Example/placeholder credentials in `.env.example`
+- Test data that looks like credentials
+
+**Fix:**
+
+##### Staged changes: Real secret detected
+
+```bash
+# Unstage the file immediately
+git reset .env
+
+# Remove or edit to remove the secret
+rm .env  # or edit to remove secrets
+
+# Stage clean version and commit
+git add .env
+git commit -m "fix: remove secret from env"
+```
+
+##### Staged changes: False positive detected
+
+```bash
+# Add to .gitleaksignore
+echo "commit-sha:path/to/file:rule-type:line-number" >> .gitleaksignore
+
+# Re-stage and commit
+git add .gitleaksignore
+git commit -m "chore: ignore false positive"
+```
+
+---
+
+#### 5.2 `scan-secrets-whole-history` — Secret Scanning (Complete History)
+
+**What it does:** Scans entire git history for embedded secrets using Gitleaks. Runs on `pre-commit run --all-files` or in CI/CD.
+
+**When it fails:**
+
+```text
+Leaks found: 1
+File: config/old-backup.tf (in commit abc1234)
+Secret: aws_access_key_id = "AKIAIOSFODNN7EXAMPLE"
 ```
 
 **Common false positives:**
@@ -529,31 +575,28 @@ Secret: aws_secret_access_key = "AKIA2EXAMPLE..."
 
 **Fix:**
 
-#### Option 1: Real secret (CRITICAL)
+##### History scan: Real secret in git history (CRITICAL)
 
 ```bash
-# Remove the secret immediately
+# Remove from history (destructive operation)
 git filter-branch --force --index-filter \
-  'git rm --cached --ignore-unmatch PATH_TO_FILE' \
+  'git rm --cached --ignore-unmatch config/old-backup.tf' \
   --prune-empty --tag-name-filter cat -- --all
 
-# Force push (warning: destructive)
+# Force push to remove from remote
 git push origin +main
+
+# IMPORTANT: Regenerate/rotate any exposed credentials
 ```
 
-#### Option 2: False positive (Add to ignore list)
+##### History scan: False positive in git history
 
 ```bash
-# Get the fingerprint from the error
 # Add to .gitleaksignore
 echo "commit-sha:path/to/file:rule-type:line-number" >> .gitleaksignore
-```
 
-**Manual run:**
-
-```bash
-gitleaks detect --verbose
-gitleaks detect -i .gitleaksignore  # With ignores
+# Re-run to verify
+pre-commit run scan-secrets-whole-history --all-files
 ```
 
 ---
@@ -764,7 +807,8 @@ fi
 | `check-english-usage` | `.md` | ❌ No | Low | Format |
 | `detect-aws-credentials` | All | ❌ No | **CRITICAL** | Security |
 | `detect-private-key` | All | ❌ No | **CRITICAL** | Security |
-| `scan-secrets` | All | ❌ No | **CRITICAL** | Security |
+| `scan-secrets-staged-changes` | All | ❌ No | **CRITICAL** | Security |
+| `scan-secrets-whole-history` | All | ❌ No | **CRITICAL** | Security |
 | `conventional-commit` | Commit msg | ❌ No | Medium | Commit |
 | `no-commit-to-branch` | N/A | ❌ No | High | Git |
 

--- a/.github/workflows/stage-1-pre-commit.yml
+++ b/.github/workflows/stage-1-pre-commit.yml
@@ -33,7 +33,7 @@ jobs:
           - name: "shell-and-content"
             hooks: >-
               shellcheck check-file-format check-markdown-format
-              check-english-usage scan-secrets
+              check-english-usage scan-secrets-whole-history
           - name: "terraform-format-lint"
             hooks: >-
               generate-terraform-providers terraform_fmt terraform_tflint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,8 +180,14 @@ repos:
         files: \.tf(vars)?$
         pass_filenames: false
 
-      - id: scan-secrets
-        name: scan-secrets
+      - id: scan-secrets-staged-changes
+        name: scan-secrets-staged-changes
+        entry: bash -c 'check=staged-changes ./scripts/githooks/scan-secrets.sh'
+        language: system
+        pass_filenames: false
+
+      - id: scan-secrets-whole-history
+        name: scan-secrets-whole-history
         entry: bash -c 'check=whole-history ./scripts/githooks/scan-secrets.sh'
         language: system
         pass_filenames: false

--- a/docs/user-guides/Pre_commit_hooks_reference.md
+++ b/docs/user-guides/Pre_commit_hooks_reference.md
@@ -49,7 +49,7 @@ Pre-commit hooks are **automated quality checks** that run before every commit. 
 - Prevent secrets from being committed
 - Save CI/CD time by fixing issues early
 
-**This repository has 26 hooks** covering Terraform, shell scripts, file formatting, security scanning, and commit message validation.
+**This repository has 27 hooks** covering Terraform, shell scripts, file formatting, security scanning, and commit message validation.
 
 ---
 
@@ -535,15 +535,17 @@ AWS credentials detected
 
 ---
 
-#### `scan-secrets` — Gitleaks
+#### `scan-secrets-staged-changes` — Gitleaks (staged files only)
 
-**What it does:** Scans entire git history for embedded secrets (API keys, credentials, etc.).
+**What it does:** Scans only the staged changes for embedded secrets (API keys, credentials, etc.).
+
+**When to use:** During pre-commit (automatically runs on `git commit`). Catches secrets before they're committed.
 
 **When it fails:**
 
 ```text
 Leaks found: 1
-File: .env.example
+File: .env
 Secret: aws_secret_access_key = "AKIA..."
 ```
 
@@ -552,13 +554,59 @@ Secret: aws_secret_access_key = "AKIA..."
 If it's a **real secret** (CRITICAL):
 
 ```bash
+# Unstage the file
+git reset .env
+
+# Remove from working directory (or edit to remove the secret)
+rm .env  # or edit to remove secrets
+
+# Stage and commit the corrected version
+git add .env
+git commit -m "fix: remove secrets"
+```
+
+If it's a **false positive** (e.g., example credentials):
+
+```bash
+# Add to .gitleaksignore
+echo "commit-sha:path/to/file:rule-type:line-number" >> .gitleaksignore
+
+# Re-stage and commit
+git add .gitleaksignore
+git commit -m "chore: ignore false positive secret scan"
+```
+
+---
+
+#### `scan-secrets-whole-history` — Gitleaks (complete history)
+
+**What it does:** Scans entire git history for embedded secrets (API keys, credentials, etc.). Runs on `pre-commit run --all-files` or in CI/CD.
+
+**When to use:** Full repository scans (CI/CD, local validation, before pushing to remote).
+
+**When it fails:**
+
+```text
+Leaks found: 1
+File: config/old-backup.tf
+Secret: aws_access_key_id = "AKIAIOSFODNN7EXAMPLE"
+Commit: abc1234
+```
+
+**Fix:**
+
+If it's a **real secret** (CRITICAL — secret is in history):
+
+```bash
 # Use git filter-branch to remove from history
 git filter-branch --force --index-filter \
-  'git rm --cached --ignore-unmatch PATH_TO_FILE' \
+  'git rm --cached --ignore-unmatch config/old-backup.tf' \
   --prune-empty --tag-name-filter cat -- --all
 
 # Force push to remove from remote
 git push origin +main
+
+# Regenerate any AWS/API credentials that were exposed
 ```
 
 If it's a **false positive** (e.g., example credentials):
@@ -568,13 +616,17 @@ If it's a **false positive** (e.g., example credentials):
 echo "commit-sha:path/to/file:rule-type:line-number" >> .gitleaksignore
 
 # Re-run to verify
-pre-commit run scan-secrets --all-files
+pre-commit run scan-secrets-whole-history --all-files
 ```
 
-**Manual run:**
+**Manual runs:**
 
 ```bash
-gitleaks detect --verbose
+# Scan staged changes only
+check=staged-changes ./scripts/githooks/scan-secrets.sh
+
+# Scan entire history
+check=whole-history ./scripts/githooks/scan-secrets.sh
 ```
 
 ---
@@ -768,7 +820,8 @@ git commit --no-verify -m "..."
 
 - `detect-aws-credentials` — detects leaked credentials
 - `detect-private-key` — detects leaked private keys
-- `scan-secrets` — scans git history for secrets
+- `scan-secrets-staged-changes` — scans staged changes for secrets
+- `scan-secrets-whole-history` — scans entire git history for secrets
 
 If you use `--no-verify`, report the issue immediately.
 

--- a/docs/user-guides/Scan_secrets.md
+++ b/docs/user-guides/Scan_secrets.md
@@ -2,6 +2,7 @@
 
 - [Guide: Scan secrets](#guide-scan-secrets)
   - [Overview](#overview)
+  - [Two-tier scanning: Staged changes + Complete history](#two-tier-scanning-staged-changes--complete-history)
   - [Key files](#key-files)
   - [Configuration checklist](#configuration-checklist)
   - [Testing](#testing)
@@ -13,13 +14,54 @@ Scanning a repository for hard-coded secrets is a crucial security practice. "Ha
 
 [Gitleaks](https://github.com/gitleaks/gitleaks) is a powerful open-source tool designed to identify hard-coded secrets and other sensitive information in Git repositories. It works by scanning the commit history and the working directory for sensitive data that should not be there.
 
+## Two-tier scanning: Staged changes + Complete history
+
+This repository uses two complementary secret scanning hooks to provide defense in depth:
+
+### `scan-secrets-staged-changes`
+
+- **When:** Runs automatically on `git commit` before the commit is created
+- **Scope:** Scans only the files you're about to commit (staged changes)
+- **Purpose:** Fast feedback loop — catches secrets before they enter the repository
+- **Time:** ~1 second (very fast)
+
+**Fix immediately if it triggers:**
+
+```bash
+# Unstage the file
+git reset .env
+
+# Remove or edit to remove the secret
+# Then stage and commit the corrected version
+git add .env
+git commit -m "fix: remove secret"
+```
+
+### `scan-secrets-whole-history`
+
+- **When:** Runs on `pre-commit run --all-files` or in CI/CD pipelines
+- **Scope:** Scans entire git history (all commits)
+- **Purpose:** Comprehensive audit — catches secrets that may have been committed before this hook existed
+- **Time:** ~10-30 seconds (slower, but thorough)
+
+**Run manually:**
+
+```bash
+# Full history scan (use before pushing to remote)
+check=whole-history ./scripts/githooks/scan-secrets.sh
+
+# Or via pre-commit
+pre-commit run scan-secrets-whole-history --all-files
+```
+
+**If it fails:** Secret is already in history; see [Removing sensitive data](#removing-sensitive-data) below for remediation.
+
 ## Key files
 
-- [`scan-secrets.sh`](../../scripts/githooks/scan-secrets.sh): A shell script that scans the codebase for hard-coded secrets
+- [`scan-secrets.sh`](../../scripts/githooks/scan-secrets.sh): A shell script that scans the codebase for hard-coded secrets (supports `check=staged-changes` and `check=whole-history` modes)
 - [`gitleaks.toml`](../../scripts/config/gitleaks.toml): A configuration file for the secret scanner
 - [`.gitleaksignore`](../../.gitleaksignore): A list of fingerprints to ignore by the secret scanner
 - [`scan-secrets/action.yaml`](../../.github/actions/scan-secrets/action.yaml): GitHub action to run the scripts as part of the CI/CD pipeline
-- [`pre-commit.yaml`](../../scripts/config/pre-commit.yaml): Run the secret scanner as a pre-commit git hook
 
 ## Configuration checklist
 
@@ -30,10 +72,18 @@ Scanning a repository for hard-coded secrets is a crucial security practice. "Ha
 
 ## Testing
 
-You can execute and test the secret scanning across all commits locally on a developer's workstation using the following command
+You can execute and test the secret scanning locally on a developer's workstation:
 
-```shell
-ALL_FILES=true ./scripts/githooks/scan-secrets.sh
+**Staged changes only (fast):**
+
+```bash
+check=staged-changes ./scripts/githooks/scan-secrets.sh
+```
+
+**Entire history (comprehensive):**
+
+```bash
+check=whole-history ./scripts/githooks/scan-secrets.sh
 ```
 
 ## Removing sensitive data


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Introduce new hooks for secret scanning that cover both staged changes and the complete git history. The `scan-secrets-staged-changes` hook runs automatically on `git commit`, while the `scan-secrets-whole-history` hook scans the entire history during CI/CD processes.

## Context

This change enhances security by providing a two-tiered approach to secret scanning, allowing for immediate detection of secrets in staged changes and comprehensive audits of the entire commit history.

## Type of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.

