### PR TITLE
ci: don’t run individual checks more than once during `git commit`

### DIFF
--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -86,4 +86,5 @@ Before committing workflow or action changes, verify:
 - [ ] Root `README.md` updated if workflow is user-facing
 - [ ] `docs/` guides updated if procedure changed
 - [ ] Workflow/action permissions are minimal (least privilege)
-- [ ] All pre-commit hooks pass: `pre-commit run --all-files`
+- [ ] All `pre-commit` stage hooks pass: `pre-commit run --all-files`
+- [ ] Manual full-history secret scan run when relevant: `pre-commit run scan-secrets-whole-history --hook-stage manual --all-files`

--- a/.github/instructions/pre-commit-hooks.instructions.md
+++ b/.github/instructions/pre-commit-hooks.instructions.md
@@ -29,8 +29,11 @@ pre-commit install --hook-type commit-msg
 ## Before Committing
 
 ```bash
-# Run all hooks locally
+# Run all pre-commit stage hooks locally
 pre-commit run --all-files
+
+# Run the full-history secret scan explicitly when needed
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
 
 # Fix any issues reported
 
@@ -44,7 +47,7 @@ git commit -m "type(scope): description"
 - `detect-aws-credentials` — detects embedded secrets
 - `detect-private-key` — detects leaked private keys
 - `scan-secrets-staged-changes` — scans staged changes for secrets (runs on `git commit`)
-- `scan-secrets-whole-history` — scans entire git history for secrets (runs on `pre-commit run --all-files`)
+- `scan-secrets-whole-history` — scans entire git history for secrets (run explicitly with `pre-commit run scan-secrets-whole-history --hook-stage manual --all-files`)
 - `terraform_validate` — ensures modules are syntactically valid
 - `regenerate-dependabot-config` — ensures Dependabot watches all modules
 - `check-available-modules` — ensures README module table is up-to-date

--- a/.github/instructions/terraform-modules.instructions.md
+++ b/.github/instructions/terraform-modules.instructions.md
@@ -103,6 +103,12 @@ pre-commit install --install-hooks
 pre-commit run --all-files
 ```
 
+If you need the full-history secret scan locally, run it explicitly:
+
+```bash
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
+```
+
 Key hooks for Terraform work:
 
 - `terraform_fmt` — enforces code formatting
@@ -272,7 +278,8 @@ Before committing, verify:
 - [ ] `infrastructure/AGENTS.md` updated if patterns changed
 - [ ] Root `README.md` updated if module list or procedures changed
 - [ ] User guide files updated if hooks or workflows changed
-- [ ] All pre-commit hooks pass: `pre-commit run --all-files`
+- [ ] All `pre-commit` stage hooks pass: `pre-commit run --all-files`
+- [ ] Manual full-history secret scan run when relevant: `pre-commit run scan-secrets-whole-history --hook-stage manual --all-files`
 
 ## Formatting & Style
 

--- a/.github/skills/pre-commit-hooks.skill.md
+++ b/.github/skills/pre-commit-hooks.skill.md
@@ -41,6 +41,14 @@ pre-commit install --hook-type commit-msg
 pre-commit run --all-files
 ```
 
+This runs hooks assigned to the `pre-commit` stage. The Conventional Commit validator runs separately during `git commit` at the `commit-msg` stage.
+
+Run the full-history secret scan explicitly when needed:
+
+```bash
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
+```
+
 If successful, output ends with:
 
 ```text
@@ -557,7 +565,7 @@ git commit -m "chore: ignore false positive"
 
 #### 5.2 `scan-secrets-whole-history` — Secret Scanning (Complete History)
 
-**What it does:** Scans entire git history for embedded secrets using Gitleaks. Runs on `pre-commit run --all-files` or in CI/CD.
+**What it does:** Scans entire git history for embedded secrets using Gitleaks. Runs only when explicitly invoked with the `manual` stage or in CI/CD.
 
 **When it fails:**
 
@@ -596,7 +604,7 @@ git push origin +main
 echo "commit-sha:path/to/file:rule-type:line-number" >> .gitleaksignore
 
 # Re-run to verify
-pre-commit run scan-secrets-whole-history --all-files
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
 ```
 
 ---
@@ -678,6 +686,14 @@ echo "feat(vpc): add IPv6 support" | pre-commit run conventional-commit --input
 
 ```bash
 pre-commit run --all-files
+```
+
+This runs hooks assigned to the `pre-commit` stage.
+
+### Run Manual-Only Hooks
+
+```bash
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
 ```
 
 ### Run Specific Hook

--- a/.github/workflows/stage-1-pre-commit.yml
+++ b/.github/workflows/stage-1-pre-commit.yml
@@ -90,17 +90,21 @@ jobs:
       # ------------------------------------------------------------------
       - name: "Run pre-commit shard"
         shell: bash
+        env:
+          AWS_DEFAULT_REGION: eu-west-2
+          hooks: ${{ matrix.shard.hooks }}
         run: |
           export TF_PLUGIN_CACHE_DIR="${HOME}/.terraform.d/plugin-cache"
-          hooks='${{ matrix.shard.hooks }}'
+          declare -A stage_by_hook=(
+            [scan-secrets-whole-history]=manual
+          )
           for hook in ${hooks}; do
             if [[ "${hook}" == "terraform_validate" ]]; then
               export TF_CLI_ARGS_init="-lockfile=readonly"
             else
               unset TF_CLI_ARGS_init
             fi
-            echo "Running hook: ${hook}"
-            mise x -- pre-commit run --all-files --show-diff-on-failure "$hook"
+            stage="${stage_by_hook[${hook}]:-pre-commit}"
+            echo "Running hook: ${hook} (stage: ${stage})"
+            mise x -- pre-commit run --all-files --show-diff-on-failure --hook-stage "$stage" "$hook"
           done
-        env:
-          AWS_DEFAULT_REGION: eu-west-2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
         language: script
         files: \.tf(vars)?$
         pass_filenames: false
+        stages: [pre-commit]
 
   # --------------------------------------------------------------------------
   # Local: regenerate Dependabot configuration for Terraform modules
@@ -55,6 +56,7 @@ repos:
         language: script
         files: infrastructure/modules/.*/versions\.tf$
         pass_filenames: false
+        stages: [pre-commit]
 
   # --------------------------------------------------------------------------
   # Local: regenerate Available modules section in README.md
@@ -76,6 +78,7 @@ repos:
         language: script
         files: (infrastructure/modules/.*/README\.md|README\.md)$
         pass_filenames: false
+        stages: [pre-commit]
 
   # --------------------------------------------------------------------------
   # Terraform hooks (format, lint, validate, docs, lock)
@@ -88,6 +91,7 @@ repos:
         - --args=-no-color
         - --args=-diff
         - --args=-recursive
+        stages: [pre-commit]
       - id: terraform_providers_lock
         args:
           - --args=-platform=linux_arm64
@@ -96,16 +100,19 @@ repos:
           - --args=-platform=darwin_amd64
           - --args=-platform=windows_amd64
           - --hook-config=--mode=regenerate-lockfile-if-some-platform-missed
+        stages: [pre-commit]
       - id: terraform_validate
         args:
           - --args=-json
           - --args=-no-color
           - --env-vars=AWS_DEFAULT_REGION=eu-west-2
           - --hook-config=--retry-once-with-cleanup=true
+        stages: [pre-commit]
       - id: terraform_tflint
         # exclude: ^infrastructure/modules/(aws-backup-destination|aws-backup-source)/
         args:
         - '--args=--config=__GIT_WORKING_DIR__/scripts/config/.tflint.hcl'
+        stages: [pre-commit]
       - id: terraform_docs
         args:
           - '--args=--lockfile=true'
@@ -114,6 +121,7 @@ repos:
           - --hook-config=--create-file-if-not-exist=false
           - '--hook-config=--custom-marker-begin=<!-- vale off -->\n<!-- markdownlint-disable -->\n<!-- BEGIN_TF_DOCS -->'
           - '--hook-config=--custom-marker-end=<!-- END_TF_DOCS -->\n<!-- markdownlint-restore -->\n<!-- vale on -->'
+        stages: [pre-commit]
 
   # --------------------------------------------------------------------------
   # General file hygiene
@@ -123,28 +131,41 @@ repos:
     hooks:
       # Git style
       - id: check-added-large-files
+        stages: [pre-commit]
       - id: check-merge-conflict
+        stages: [pre-commit]
       - id: check-vcs-permalinks
+        stages: [pre-commit]
       - id: forbid-new-submodules
+        stages: [pre-commit]
       - id: no-commit-to-branch
+        stages: [pre-commit]
 
       # Common errors
       - id: end-of-file-fixer
+        stages: [pre-commit]
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
         exclude: CHANGELOG.md
+        stages: [pre-commit]
       - id: check-yaml
+        stages: [pre-commit]
       - id: check-executables-have-shebangs
+        stages: [pre-commit]
 
       # Cross platform
       - id: check-case-conflict
+        stages: [pre-commit]
       - id: mixed-line-ending
         args: [--fix=lf]
+        stages: [pre-commit]
 
       # Security
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
+        stages: [pre-commit]
       - id: detect-private-key
+        stages: [pre-commit]
 
   # --------------------------------------------------------------------------
   # Shell script linting (uses scripts/shellscript-linter.sh; runs natively if
@@ -164,6 +185,7 @@ repos:
         language: system
         types: [shell]
         require_serial: true
+        stages: [pre-commit]
 
   # --------------------------------------------------------------------------
   # Repository githook wrappers (native tool if available, Docker fallback)
@@ -179,6 +201,7 @@ repos:
         entry: bash -c 'check=all ./scripts/githooks/check-file-format.sh'
         language: system
         pass_filenames: false
+        stages: [pre-commit]
 
       - id: check-markdown-format
         name: check-markdown-format
@@ -186,6 +209,7 @@ repos:
         language: system
         files: \.md$
         pass_filenames: false
+        stages: [pre-commit]
 
       - id: check-english-usage
         name: check-english-usage
@@ -193,6 +217,7 @@ repos:
         language: system
         files: \.md$
         pass_filenames: false
+        stages: [pre-commit]
 
       - id: check-terraform-format
         name: check-terraform-format
@@ -200,18 +225,21 @@ repos:
         language: system
         files: \.tf(vars)?$
         pass_filenames: false
+        stages: [pre-commit]
 
       - id: scan-secrets-staged-changes
         name: scan-secrets-staged-changes
         entry: bash -c 'check=staged-changes ./scripts/githooks/scan-secrets.sh'
         language: system
         pass_filenames: false
+        stages: [pre-commit]
 
       - id: scan-secrets-whole-history
         name: scan-secrets-whole-history
         entry: bash -c 'check=whole-history ./scripts/githooks/scan-secrets.sh'
         language: system
         pass_filenames: false
+        stages: [pre-commit]
 
   # --------------------------------------------------------------------------
   # Conventional Commits (commit message format)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -239,7 +239,7 @@ repos:
         entry: bash -c 'check=whole-history ./scripts/githooks/scan-secrets.sh'
         language: system
         pass_filenames: false
-        stages: [pre-commit]
+        stages: [manual]
 
   # --------------------------------------------------------------------------
   # Conventional Commits (commit message format)

--- a/README.md
+++ b/README.md
@@ -365,9 +365,14 @@ For Terraform-related matrix shards, CI enables `TF_PLUGIN_CACHE_DIR` and caches
 pre-commit install --install-hooks
 pre-commit install --hook-type commit-msg
 
-# Run all hooks against the full repo
+# Run all pre-commit stage hooks against the full repo
 pre-commit run --all-files
+
+# Run the full-history secret scan explicitly when needed
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
 ```
+
+On `git commit`, repository checks now run once at the `pre-commit` stage, and the Conventional Commit validator runs separately at the `commit-msg` stage. The full-history secret scan is intentionally excluded from normal commits and `pre-commit run --all-files`; CI runs it explicitly via the `manual` stage.
 
 ### Hooks included
 
@@ -548,7 +553,7 @@ bash tests/test-workflow-security.sh verbose
 ## Contributing
 
 1. Create a feature branch from `main`.
-2. Run `pre-commit run --all-files` before pushing.
+2. Run `pre-commit run --all-files` before pushing, and run `pre-commit run scan-secrets-whole-history --hook-stage manual --all-files` when you need a full-history secret scan locally.
 3. Ensure commit messages follow the [Conventional Commits](#conventional-commits) format.
 4. Open a pull request — the `pre-commit.yml` workflow will validate all hooks pass.
 5. All modules must include the required files listed in [Module layout](#module-layout) and meet the [security baseline](#wrapper-module-pattern).

--- a/docs/user-guides/Pre_commit_hooks_reference.md
+++ b/docs/user-guides/Pre_commit_hooks_reference.md
@@ -29,12 +29,17 @@ This is the comprehensive reference for all pre-commit hooks in the `screening-t
 pre-commit install --install-hooks
 pre-commit install --hook-type commit-msg
 
-# Run all hooks on the entire repository
+# Run all pre-commit stage hooks on the entire repository
 pre-commit run --all-files
+
+# Run the full-history secret scan explicitly
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
 
 # On next commit, hooks run automatically
 git commit -m "feat(module): description"
 ```
+
+During `git commit`, repository checks run at the `pre-commit` stage and the Conventional Commit validator runs at the `commit-msg` stage. `scan-secrets-whole-history` is assigned to the `manual` stage so it does not run on every commit.
 
 ---
 
@@ -756,7 +761,7 @@ git commit -m "chore: ignore false positive secret scan"
 
 #### `scan-secrets-whole-history` — Gitleaks (complete history)
 
-**What it does:** Scans entire git history for embedded secrets (API keys, credentials, etc.). Runs on `pre-commit run --all-files` or in CI/CD.
+**What it does:** Scans entire git history for embedded secrets (API keys, credentials, etc.). Runs only when explicitly invoked with the `manual` stage or in CI/CD.
 
 **When to use:** Full repository scans (CI/CD, local validation, before pushing to remote).
 
@@ -792,7 +797,7 @@ If it's a **false positive** (e.g., example credentials):
 echo "commit-sha:path/to/file:rule-type:line-number" >> .gitleaksignore
 
 # Re-run to verify
-pre-commit run scan-secrets-whole-history --all-files
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
 ```
 
 **Manual runs:**
@@ -962,6 +967,14 @@ code .vale.ini
 
 ```bash
 pre-commit run --all-files
+```
+
+This runs hooks assigned to the `pre-commit` stage.
+
+### Manual-Only Hooks
+
+```bash
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
 ```
 
 ### Specific Hook

--- a/docs/user-guides/Run_Git_hooks_on_commit.md
+++ b/docs/user-guides/Run_Git_hooks_on_commit.md
@@ -37,6 +37,14 @@ pre-commit install --hook-type commit-msg
 pre-commit run --all-files
 ```
 
+This command runs hooks assigned to the `pre-commit` stage. The Conventional Commit validator runs separately during `git commit` at the `commit-msg` stage.
+
+If you want the complete history secret scan locally, run it explicitly:
+
+```bash
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
+```
+
 If successful, output ends with:
 
 ```text
@@ -58,8 +66,11 @@ Passed: X, Failed: 0, Skipped: Y
 Run hooks locally to validate code before committing:
 
 ```bash
-# Test all hooks on the entire repository
+# Test all pre-commit stage hooks on the entire repository
 pre-commit run --all-files
+
+# Test the full-history secret scan explicitly
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
 
 # Test a specific hook
 pre-commit run terraform_fmt --all-files

--- a/docs/user-guides/Scan_secrets.md
+++ b/docs/user-guides/Scan_secrets.md
@@ -39,7 +39,7 @@ git commit -m "fix: remove secret"
 
 ### `scan-secrets-whole-history`
 
-- **When:** Runs on `pre-commit run --all-files` or in CI/CD pipelines
+- **When:** Runs only when explicitly invoked with the `manual` stage or in CI/CD pipelines
 - **Scope:** Scans entire git history (all commits)
 - **Purpose:** Comprehensive audit — catches secrets that may have been committed before this hook existed
 - **Time:** ~10-30 seconds (slower, but thorough)
@@ -51,7 +51,7 @@ git commit -m "fix: remove secret"
 check=whole-history ./scripts/githooks/scan-secrets.sh
 
 # Or via pre-commit
-pre-commit run scan-secrets-whole-history --all-files
+pre-commit run scan-secrets-whole-history --hook-stage manual --all-files
 ```
 
 **If it fails:** Secret is already in history; see [Removing sensitive data](#removing-sensitive-data) below for remediation.

--- a/scripts/config/vale/styles/config/vocabularies/words/accept.txt
+++ b/scripts/config/vale/styles/config/vocabularies/words/accept.txt
@@ -110,6 +110,7 @@ tracing_mode
 Trufflehog
 URL
 url
+validator
 [Vv]alkey
 vault_lock_type
 vault_name


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

1. Previously, most pre-commit hooks were being run twice during `git commit`. This PR makes them run only once.

2. Prevent the `scan-secrets-whole-history` hook from being run during `git commit` (we already run the `scan-secrets-staged-changes` hook), while still running it during CI.

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
